### PR TITLE
Added reading arguments on startup

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -159,9 +159,7 @@ function GameServer() {
     this.setBorder(this.config.borderWidth, this.config.borderHeight);
     this.quadTree = new QuadNode(this.border);
     
-    // Gamemodes
-    var Gamemode = require('./gamemodes');
-    this.gameMode = Gamemode.get(this.config.serverGamemode);
+    
 }
 
 module.exports = GameServer;
@@ -170,6 +168,10 @@ GameServer.prototype.start = function() {
     this.timerLoopBind = this.timerLoop.bind(this);
     this.mainLoopBind = this.mainLoop.bind(this);
 
+	// Gamemodes
+    var Gamemode = require('./gamemodes');
+    this.gameMode = Gamemode.get(this.config.serverGamemode);
+	
     // Gamemode configurations
     this.gameMode.onServerInit(this);
     

--- a/src/gamemodes/index.js
+++ b/src/gamemodes/index.js
@@ -8,7 +8,7 @@ module.exports = {
 
 var get = function (id) {
     var mode;
-    switch (id) {
+    switch (parseInt(id)) {
         case 1: // Teams
             mode = new module.exports.Teams();
             break;

--- a/src/index.js
+++ b/src/index.js
@@ -20,21 +20,84 @@ process.on('uncaughtException', function (err) {
     process.exit(1);
 });
 
-// Handle arguments
-process.argv.forEach(function (val) {
-    if (val == "--noconsole") {
-        showConsole = false;
-    } else if (val == "--help") {
-        console.log("Proper Usage: node index.js");
-        console.log("    --noconsole         Disables the console");
-        console.log("    --help              Help menu.");
-        console.log("");
-    }
-});
-
 // Run Ogar
 var gameServer = new GameServer();
 Logger.info("\u001B[1m\u001B[32mMultiOgar-Edited " + gameServer.version + "\u001B[37m - An open source multi-protocol ogar server\u001B[0m");
+
+// Handle arguments
+process.argv.forEach(function (item) {
+    
+    switch (item){
+        case "--help":
+            console.log("Proper Usage: node index.js");
+            console.log("    -n, --name             Set name");
+            console.log("    -g, --gameport         Set game port");
+            console.log("    -s, --statsport        Set stats port");
+            console.log("    -m, --gamemode         Set game mode (id)");
+            console.log("    -c, --connections      Set max connections limit");
+            console.log("    -t, --tracker          Set serverTracker");
+            console.log("    --noconsole            Disables the console");
+            console.log("    --help                 Help menu");
+            console.log("");
+            break;
+            
+        case "-n": 
+        case "--name": 
+            setParam("serverName", getValue(item));
+            break;
+            
+        case "-g": 
+        case "--gameport": 
+            setParam("serverPort", parseInt(getValue(item)));
+            break;
+        case "-s": 
+        case "--statsport": 
+            setParam("serverStatsPort", parseInt(getValue(item)));
+            break;
+            
+        case "-m": 
+        case "--gamemode":
+            setParam("serverGamemode", getValue(item));
+            break;
+            
+        case "-c": 
+        case "--connections":
+            setParam("serverMaxConnections", parseInt(getValue(item)));
+            break;
+        case "-t": 
+        case "--tracker":
+            setParam("serverTracker", parseInt(getValue(item)));
+            break;
+        
+        case "--noconsole":
+            showConsole = false;
+            break;
+    }
+});
+
+function getValue(param){
+    var ind = process.argv.indexOf(param);
+    if (process.argv[ind + 1].indexOf('-') != -1){
+        Logger.error("No value for " + param);
+        return null;
+    } else{
+        return process.argv[ind + 1];
+    }
+}
+
+function setParam(paramName, val){
+    if (!gameServer.config.hasOwnProperty(paramName)){
+        Logger.error("Wrong parameter");
+    }
+    if (val) {
+        if (typeof val === 'string'){
+            val = "'" + val + "'";
+        }
+        eval("gameServer.config." + paramName + "=" + val);
+    }
+}
+
+
 gameServer.start();
 figlet(('MultiOgar-Edited  ' + gameServer.version), function(err, data) {
      if (err) {


### PR DESCRIPTION
Added ability to set some useful params right on start. 

Available params
```
-n, --name             Set name
-g, --gameport         Set game port    
-s, --statsport        Set stats port    
-m, --gamemode         Set game mode (id)    
-c, --connections      Set max connections limit    
-t, --tracker          Set serverTracker    
--noconsole            Disables the console    
--help                 Help menu    
```

These params temporary overrides values in gameserver.ini for launching instance 

![image](https://cloud.githubusercontent.com/assets/10178982/23747802/a42c4696-04c9-11e7-94f3-344b53fc77ce.png)
