### PR TITLE
Added a way to change the logger colorscheme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ var figlet = require('figlet');
 var showConsole = true;
 
 // Start msg
+setLoggerColorscheme();
 Logger.start();
 
 process.on('exit', function (code) {
@@ -36,6 +37,7 @@ process.argv.forEach(function (item) {
             console.log("    -m, --gamemode         Set game mode (id)");
             console.log("    -c, --connections      Set max connections limit");
             console.log("    -t, --tracker          Set serverTracker");
+            console.log("    -l, --light-background Set a light-background colorscheme for logger")
             console.log("    --noconsole            Disables the console");
             console.log("    --help                 Help menu");
             console.log("");
@@ -68,12 +70,24 @@ process.argv.forEach(function (item) {
         case "--tracker":
             setParam("serverTracker", parseInt(getValue(item)));
             break;
+
+        case "-l":
+        case "--light-background":
+            //Has already been processed before logger initialisation
+            break;
         
         case "--noconsole":
             showConsole = false;
             break;
     }
 });
+
+function setLoggerColorscheme(){
+    if (process.argv.indexOf("-l") != -1
+        || process.argv.indexOf("--light-background") != -1) {
+        Logger.setLightBackgroundColorscheme();
+    }
+}
 
 function getValue(param){
     var ind = process.argv.indexOf(param);

--- a/src/modules/Logger.js
+++ b/src/modules/Logger.js
@@ -36,38 +36,44 @@ module.exports.getVerbosity = function () {
 module.exports.getFileVerbosity = function () {
     return logFileVerbosity;
 };
+module.exports.setLightBackgroundColorscheme = function () {
+    colorscheme = light_background_colorscheme;
+}
+module.exports.setDarkBackgroundColorscheme = function () {
+    colorscheme = dark_background_colorscheme;
+}
 
 
 var logVerbosity = LogLevelEnum.DEBUG;
 var logFileVerbosity = LogLevelEnum.DEBUG;
 
 function debug(message) {
-    writeCon(colorWhite, LogLevelEnum.DEBUG, message);
+    writeCon(colorscheme.debug, LogLevelEnum.DEBUG, message);
     writeLog(LogLevelEnum.DEBUG, message);
 };
 
 function info(message) {
-    writeCon(colorWhite + colorBright, LogLevelEnum.INFO, message);
+    writeCon(colorscheme.info, LogLevelEnum.INFO, message);
     writeLog(LogLevelEnum.INFO, message);
 };
 
 function warn(message) {
-    writeCon(colorYellow + colorBright, LogLevelEnum.WARN, message);
+    writeCon(colorscheme.warn, LogLevelEnum.WARN, message);
     writeLog(LogLevelEnum.WARN, message);
 };
 
 function error(message) {
-    writeCon(colorRed + colorBright, LogLevelEnum.ERROR, message);
+    writeCon(colorscheme.error, LogLevelEnum.ERROR, message);
     writeLog(LogLevelEnum.ERROR, message);
 };
 
 function fatal(message) {
-    writeCon(colorRed + colorBright, LogLevelEnum.FATAL, message);
+    writeCon(colorscheme.fatal, LogLevelEnum.FATAL, message);
     writeLog(LogLevelEnum.FATAL, message);
 };
 
 function print(message) {
-    writeCon(colorWhite, LogLevelEnum.NONE, message);
+    writeCon(colorscheme.print, LogLevelEnum.NONE, message);
     writeLog(LogLevelEnum.NONE, message);
 };
 
@@ -248,12 +254,12 @@ function shutdown() {
     flushSync();
 };
 
-
 var logFolder = "./logs";
 var logBackupFolder = "./logs/LogBackup";
 var logFileName = "ServerLog";
 
 var consoleLog = null;
+
 var colorBlack = "\u001B[30m";
 var colorRed = "\u001B[31m";
 var colorGreen = "\u001B[32m";
@@ -263,3 +269,23 @@ var colorMagenta = "\u001B[35m";
 var colorCyan = "\u001B[36m";
 var colorWhite = "\u001B[37m";
 var colorBright = "\u001B[1m";
+
+var light_background_colorscheme = {
+    debug: colorBlack,
+    info: colorBlack + colorBright,
+    warn: colorYellow + colorBright,
+    error: colorRed + colorBright,
+    fatal: colorRed + colorBright,
+    print: colorBlack
+};
+
+var dark_background_colorscheme = {
+    debug: colorWhite,
+    info: colorWhite + colorBright,
+    warn: colorYellow + colorBright,
+    error: colorRed + colorBright,
+    fatal: colorRed + colorBright,
+    print: colorWhite
+};
+
+var colorscheme = dark_background_colorscheme;


### PR DESCRIPTION
Hi, I added a way to change the logger colorscheme for terminal with a light background because the current colorscheme is unreadable on these kind of terminal.

While editing the files I noticed that the `colorBright` value does not actually make the color brighter but make the text bold, maybe I am mistaken, would it be alright to change the name to `textBold` or something of the same test? I'm asking this here because it is really a small thing to change.