### PR TITLE
HungerGames/Tournament gamemodes and Fixes Gamemodes

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -137,6 +137,14 @@ function GameServer() {
         serverMinions: 0,           // Amount of minions each player gets once they spawn
         collectPellets: 0,          // Enable collect pellets mode. To use just press P or Q. (Warning: this disables Q controls, so make sure that disableERT is 0)
         defaultName: "minion",      // Default name for all minions if name is not specified using command (put <r> before the name for random skins!)
+
+        /** TOURNAMENT **/
+        tourneyMaxPlayers: 12,      // Maximum number of participants for tournament style game modes
+        tourneyPrepTime: 10,        // Number of ticks to wait after all players are ready (1 tick = 1000 ms)
+        tourneyEndTime: 30,         // Number of ticks to wait after a player wins (1 tick = 1000 ms)
+        tourneyTimeLimit: 20,       // Time limit of the game, in minutes.
+        tourneyAutoFill: 0,         // If set to a value higher than 0, the tournament match will automatically fill up with bots after this amount of seconds
+        tourneyAutoFillPlayers: 1,  // The timer for filling the server with bots will not count down unless there is this amount of real players
     };
 
     this.ipBanList = [];

--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -596,6 +596,8 @@ GameServer.prototype.mainLoop = function() {
         this.gameMode.onTick(this);
         this.tickCounter++;
     }
+    if(!this.run && this.gameMode.IsTournament)
+       this.tickCounter++;
     this.updateClients();
 
     // update leaderboard

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -37,4 +37,6 @@ PlayerCell.prototype.onRemove = function (gameServer) {
 
     index = this.gameServer.nodesPlayer.indexOf(this);
     if (index != -1) this.gameServer.nodesPlayer.splice(index, 1);
+    // Gamemode actions
+    gameServer.gameMode.onCellRemove(this);
 };

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -1,6 +1,5 @@
 var FFA = require('./FFA'); // Base gamemode
 var Entity = require('../entity');
-var Logger = require('../modules/Logger');
 
 function Experimental() {
     FFA.apply(this, Array.prototype.slice.call(arguments));

--- a/src/gamemodes/HungerGames.js
+++ b/src/gamemodes/HungerGames.js
@@ -145,7 +145,9 @@ HungerGames.prototype.onServerInit = function (gameServer) {
     gameServer.config.virusMaxAmount = 100;
     gameServer.config.ejectSpawnPlayer = 0;
     gameServer.config.playerDisconnectTime = 10; // So that people dont disconnect and stall the game for too long
-    
+    gameServer.setBorder(
+        gameServer.border.width,
+        gameServer.border.height);
     // Spawn Initial Virus/Large food
     var mapWidth = gameServer.border.width;
     var mapHeight = gameServer.border.height;
@@ -290,7 +292,7 @@ HungerGames.prototype.onServerInit = function (gameServer) {
 HungerGames.prototype.onPlayerSpawn = function (gameServer, player) {
     // Only spawn players if the game hasnt started yet
     if ((this.gamePhase == 0) && (this.contenders.length < this.maxContenders)) {
-        player.setColor(gameServer.getRandomColor()); // Random color
+        player.color = gameServer.getRandomColor(); // Random color
         this.contenders.push(player); // Add to contenders list
         gameServer.spawnPlayer(player, this.getPos());
         

--- a/src/gamemodes/HungerGames.js
+++ b/src/gamemodes/HungerGames.js
@@ -99,7 +99,7 @@ HungerGames.prototype.onPlayerDeath = function (gameServer) {
     for (var i = 0; i < len; i++) {
         var node = gameServer.nodes[i];
         
-        if ((!node) || (node.getType() == 0)) {
+        if ((!node) || (node.cellType == 0)) {
             continue;
         }
         

--- a/src/gamemodes/HungerGames.js
+++ b/src/gamemodes/HungerGames.js
@@ -80,7 +80,7 @@ HungerGames.prototype.getPos = function () {
 
 HungerGames.prototype.spawnFood = function (gameServer, mass, pos) {
     var cell = new Entity.Food(gameServer, null, pos, mass);
-    cell.setColor(gameServer.getRandomColor());
+    cell.color = gameServer.getRandomColor();
     gameServer.addNode(cell);
 };
 

--- a/src/gamemodes/HungerGames.js
+++ b/src/gamemodes/HungerGames.js
@@ -1,0 +1,302 @@
+var Tournament = require('./Tournament');
+var Entity = require('../entity');
+
+function HungerGames() {
+    Tournament.apply(this, Array.prototype.slice.call(arguments));
+    
+    this.ID = 5;
+    this.name = "Hunger Games";
+    
+    // Gamemode Specific Variables
+    this.maxContenders = 12;
+    this.baseSpawnPoints = [{
+            x: 1600,
+            y: 200
+        }, {
+            x: 3200,
+            y: 200
+        }, {
+            x: 4800,
+            y: 200
+        }, // Top
+        {
+            x: 200,
+            y: 1600
+        }, {
+            x: 200,
+            y: 3200
+        }, {
+            x: 200,
+            y: 4800
+        }, // Left
+        {
+            x: 6200,
+            y: 1600
+        }, {
+            x: 6200,
+            y: 3200
+        }, {
+            x: 6200,
+            y: 4800
+        }, // Right
+        {
+            x: 1600,
+            y: 6200
+        }, {
+            x: 3200,
+            y: 6200
+        }, {
+            x: 4800,
+            y: 6200
+        } // Bottom
+    ];
+    this.contenderSpawnPoints;
+    this.borderDec = 100; // Border shrinks by this size everytime someone dies
+}
+
+module.exports = HungerGames;
+HungerGames.prototype = new Tournament();
+
+// Gamemode Specific Functions
+
+HungerGames.prototype.getPos = function () {
+    var pos = {
+        x: 0,
+        y: 0
+    };
+    
+    // Random Position
+    if (this.contenderSpawnPoints.length > 0) {
+        var index = Math.floor(Math.random() * this.contenderSpawnPoints.length);
+        pos = this.contenderSpawnPoints[index];
+        this.contenderSpawnPoints.splice(index, 1);
+    }
+    
+    return {
+        x: pos.x,
+        y: pos.y
+    };
+};
+
+HungerGames.prototype.spawnFood = function (gameServer, mass, pos) {
+    var cell = new Entity.Food(gameServer, null, pos, mass);
+    cell.setColor(gameServer.getRandomColor());
+    gameServer.addNode(cell);
+};
+
+HungerGames.prototype.spawnVirus = function (gameServer, pos) {
+    var v = new Entity.Virus(gameServer, null, pos, gameServer.config.virusMinSize);
+    gameServer.addNode(v);
+};
+
+HungerGames.prototype.onPlayerDeath = function (gameServer) {
+    gameServer.setBorder(
+        gameServer.border.width - this.borderDec * 2, 
+        gameServer.border.height - this.borderDec * 2);
+    
+    // Remove all cells
+    var len = gameServer.nodes.length;
+    for (var i = 0; i < len; i++) {
+        var node = gameServer.nodes[i];
+        
+        if ((!node) || (node.getType() == 0)) {
+            continue;
+        }
+        
+        // Move
+        if (node.position.x < gameServer.border.minx) {
+            gameServer.removeNode(node);
+            i--;
+        } else if (node.position.x > gameServer.border.maxx) {
+            gameServer.removeNode(node);
+            i--;
+        } else if (node.position.y < gameServer.border.miny) {
+            gameServer.removeNode(node);
+            i--;
+        } else if (node.position.y > gameServer.border.maxy) {
+            gameServer.removeNode(node);
+            i--;
+        }
+    }
+};
+
+// Override
+
+HungerGames.prototype.onServerInit = function (gameServer) {
+    // Prepare
+    this.prepare(gameServer);
+    
+    // Resets spawn points
+    this.contenderSpawnPoints = this.baseSpawnPoints.slice();
+    
+    // Override config values
+    if (gameServer.config.serverBots > this.maxContenders) {
+        // The number of bots cannot exceed the maximum amount of contenders
+        gameServer.config.serverBots = this.maxContenders;
+    }
+    gameServer.config.spawnInterval = 20;
+    gameServer.config.borderWidth = 3200;
+    gameServer.config.borderHeight = 3200;
+    gameServer.config.foodSpawnAmount = 5; // This is hunger games
+    gameServer.config.foodMinAmount = 100;
+    gameServer.config.foodMaxAmount = 200;
+    gameServer.config.foodMinSize = 10; // Food is scarce, but its worth more
+    gameServer.config.virusMinAmount = 10; // We need to spawn some viruses in case someone eats them all
+    gameServer.config.virusMaxAmount = 100;
+    gameServer.config.ejectSpawnPlayer = 0;
+    gameServer.config.playerDisconnectTime = 10; // So that people dont disconnect and stall the game for too long
+    
+    // Spawn Initial Virus/Large food
+    var mapWidth = gameServer.border.width;
+    var mapHeight = gameServer.border.height;
+    
+    // Food
+    this.spawnFood(gameServer, 200, {
+        x: mapWidth * .5,
+        y: mapHeight * .5
+    }); // Center
+    this.spawnFood(gameServer, 80, {
+        x: mapWidth * .4,
+        y: mapHeight * .6
+    }); //
+    this.spawnFood(gameServer, 80, {
+        x: mapWidth * .6,
+        y: mapHeight * .6
+    });
+    this.spawnFood(gameServer, 80, {
+        x: mapWidth * .4,
+        y: mapHeight * .4
+    });
+    this.spawnFood(gameServer, 80, {
+        x: mapWidth * .6,
+        y: mapHeight * .4
+    });
+    this.spawnFood(gameServer, 50, {
+        x: mapWidth * .7,
+        y: mapHeight * .5
+    }); //
+    this.spawnFood(gameServer, 50, {
+        x: mapWidth * .3,
+        y: mapHeight * .5
+    });
+    this.spawnFood(gameServer, 50, {
+        x: mapWidth * .5,
+        y: mapHeight * .7
+    });
+    this.spawnFood(gameServer, 50, {
+        x: mapWidth * .5,
+        y: mapHeight * .3
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .7,
+        y: mapHeight * .625
+    }); // Corner
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .625,
+        y: mapHeight * .7
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .3,
+        y: mapHeight * .4
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .4,
+        y: mapHeight * .3
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .6,
+        y: mapHeight * .3
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .7,
+        y: mapHeight * .4
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .3,
+        y: mapHeight * .6
+    });
+    this.spawnFood(gameServer, 30, {
+        x: mapWidth * .4,
+        y: mapHeight * .7
+    });
+    
+    // Virus
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .6,
+        y: mapHeight * .5
+    }); //
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .4,
+        y: mapHeight * .5
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .5,
+        y: mapHeight * .4
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .5,
+        y: mapHeight * .6
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .3,
+        y: mapHeight * .3
+    }); //
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .3,
+        y: mapHeight * .7
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .7,
+        y: mapHeight * .3
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .7,
+        y: mapHeight * .7
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .25,
+        y: mapHeight * .6
+    }); //
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .25,
+        y: mapHeight * .4
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .75,
+        y: mapHeight * .6
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .75,
+        y: mapHeight * .4
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .6,
+        y: mapHeight * .25
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .4,
+        y: mapHeight * .25
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .6,
+        y: mapHeight * .75
+    });
+    this.spawnVirus(gameServer, {
+        x: mapWidth * .4,
+        y: mapHeight * .75
+    });
+};
+
+HungerGames.prototype.onPlayerSpawn = function (gameServer, player) {
+    // Only spawn players if the game hasnt started yet
+    if ((this.gamePhase == 0) && (this.contenders.length < this.maxContenders)) {
+        player.setColor(gameServer.getRandomColor()); // Random color
+        this.contenders.push(player); // Add to contenders list
+        gameServer.spawnPlayer(player, this.getPos());
+        
+        if (this.contenders.length == this.maxContenders) {
+            // Start the game once there is enough players
+            this.startGamePrep(gameServer);
+        }
+    }
+};

--- a/src/gamemodes/Mode.js
+++ b/src/gamemodes/Mode.js
@@ -5,6 +5,7 @@ function Mode() {
     this.packetLB = 49; // Packet id for leaderboard packet (48 = Text List, 49 = List, 50 = Pie chart)
     this.haveTeams = false; // True = gamemode uses teams, false = gamemode doesnt use teams
     this.specByLeaderboard = false; // false = spectate from player list instead of leaderboard
+    this.IsTournament = false;
 }
 
 module.exports = Mode;

--- a/src/gamemodes/Rainbow.js
+++ b/src/gamemodes/Rainbow.js
@@ -1,5 +1,4 @@
 var FFA = require('./FFA'); // Base gamemode
-var Food = require('../entity/Food');
 
 function Rainbow() {
     FFA.apply(this, Array.prototype.slice.call(arguments));

--- a/src/gamemodes/Tournament.js
+++ b/src/gamemodes/Tournament.js
@@ -1,0 +1,246 @@
+var Mode = require('./Mode');
+
+function Tournament() {
+    Mode.apply(this, Array.prototype.slice.call(arguments));
+    
+    this.ID = 4;
+    this.name = "Tournament";
+    this.packetLB = 48;
+    this.IsTournament = true;
+    // Config (1 tick = 1000 ms)
+    this.prepTime = 5; // Amount of ticks after the server fills up to wait until starting the game
+    this.endTime = 15; // Amount of ticks after someone wins to restart the game
+    this.autoFill = false;
+    this.autoFillPlayers = 1;
+    this.dcTime = 0;
+    
+    // Gamemode Specific Variables
+    this.gamePhase = 0; // 0 = Waiting for players, 1 = Prepare to start, 2 = Game in progress, 3 = End
+    this.contenders = [];
+    this.maxContenders = 12;
+    
+    this.winner;
+    this.timer;
+    this.timeLimit = 3600; // in seconds
+}
+
+module.exports = Tournament;
+Tournament.prototype = new Mode();
+
+// Gamemode Specific Functions
+
+Tournament.prototype.startGamePrep = function (gameServer) {
+    this.gamePhase = 1;
+    this.timer = this.prepTime; // 10 seconds
+};
+
+Tournament.prototype.startGame = function (gameServer) {
+    gameServer.run = true;
+    this.gamePhase = 2;
+    this.getSpectate(); // Gets a random person to spectate
+    gameServer.config.playerDisconnectTime = this.dcTime; // Reset config
+};
+
+Tournament.prototype.endGame = function (gameServer) {
+    this.winner = this.contenders[0];
+    this.gamePhase = 3;
+    this.timer = this.endTime; // 30 Seconds
+};
+
+Tournament.prototype.endGameTimeout = function (gameServer) {
+    gameServer.run = false;
+    this.gamePhase = 4;
+    this.timer = this.endTime; // 30 Seconds
+};
+
+Tournament.prototype.fillBots = function (gameServer) {
+    // Fills the server with bots if there arent enough players
+    var fill = this.maxContenders - this.contenders.length;
+    for (var i = 0; i < fill; i++) {
+        gameServer.bots.addBot();
+    }
+};
+
+Tournament.prototype.getSpectate = function () {
+    // Finds a random person to spectate
+    var index = Math.floor(Math.random() * this.contenders.length);
+    this.rankOne = this.contenders[index];
+};
+
+Tournament.prototype.prepare = function (gameServer) {
+    // Remove all cells
+    var len = gameServer.nodes.length;
+    for (var i = 0; i < len; i++) {
+        var node = gameServer.nodes[0];
+        
+        if (!node) {
+            continue;
+        }
+        
+        gameServer.removeNode(node);
+    }
+    
+    gameServer.bots.loadNames();
+    
+    // Pauses the server
+    gameServer.run = false;
+    this.gamePhase = 0;
+    
+    // Get config values
+    if (gameServer.config.tourneyAutoFill > 0) {
+        this.timer = gameServer.config.tourneyAutoFill;
+        this.autoFill = true;
+        this.autoFillPlayers = gameServer.config.tourneyAutoFillPlayers;
+    }
+    // Handles disconnections
+    this.dcTime = gameServer.config.playerDisconnectTime;
+    gameServer.config.playerDisconnectTime = 0;
+    
+    this.prepTime = gameServer.config.tourneyPrepTime;
+    this.endTime = gameServer.config.tourneyEndTime;
+    this.maxContenders = gameServer.config.tourneyMaxPlayers;
+    
+    // Time limit
+    this.timeLimit = gameServer.config.tourneyTimeLimit * 60; // in seconds
+};
+
+Tournament.prototype.onPlayerDeath = function (gameServer) {
+    // Nothing
+};
+
+Tournament.prototype.formatTime = function (time) {
+    if (time < 0) {
+        return "0:00";
+    }
+    // Format
+    var min = Math.floor(this.timeLimit / 60);
+    var sec = this.timeLimit % 60;
+    sec = (sec > 9) ? sec : "0" + sec.toString();
+    return min + ":" + sec;
+};
+
+// Override
+
+Tournament.prototype.onServerInit = function (gameServer) {
+    this.prepare(gameServer);
+};
+
+Tournament.prototype.onPlayerSpawn = function (gameServer, player) {
+    // Only spawn players if the game hasnt started yet
+    if ((this.gamePhase == 0) && (this.contenders.length < this.maxContenders)) {
+        player.setColor(gameServer.getRandomColor()); // Random color
+        this.contenders.push(player); // Add to contenders list
+        gameServer.spawnPlayer(player);
+        
+        if (this.contenders.length == this.maxContenders) {
+            // Start the game once there is enough players
+            this.startGamePrep(gameServer);
+        }
+    }
+};
+
+Tournament.prototype.onCellRemove = function (cell) {
+    var owner = cell.owner,
+        human_just_died = false;
+    
+    if (owner.cells.length <= 0) {
+        // Remove from contenders list
+        var index = this.contenders.indexOf(owner);
+        if (index != -1) {
+            if ('_socket' in this.contenders[index].socket) {
+                human_just_died = true;
+            }
+            this.contenders.splice(index, 1);
+        }
+        
+        // Victory conditions
+        var humans = 0;
+        for (var i = 0; i < this.contenders.length; i++) {
+            if ('_socket' in this.contenders[i].socket) {
+                humans++;
+            }
+        }
+        
+        // the game is over if:
+        // 1) there is only 1 player left, OR
+        // 2) all the humans are dead, OR
+        // 3) the last-but-one human just died
+        if ((this.contenders.length == 1 || humans == 0 || (humans == 1 && human_just_died)) && this.gamePhase == 2) {
+            this.endGame(cell.owner.gameServer);
+        } else {
+            // Do stuff
+            this.onPlayerDeath(cell.owner.gameServer);
+        }
+    }
+};
+
+Tournament.prototype.updateLB = function (gameServer, lb) {
+    gameServer.leaderboardType = this.packetLB;
+    switch (this.gamePhase) {
+        case 0:
+            lb[0] = "Waiting for";
+            lb[1] = "players: ";
+            lb[2] = this.contenders.length + "/" + this.maxContenders;
+            if (this.autoFill) {
+                if (this.timer <= 0) {
+                    this.fillBots(gameServer);
+                } else if (this.contenders.length >= this.autoFillPlayers) {
+                    this.timer--;
+                }
+            }
+            break;
+        case 1:
+            lb[0] = "Game starting in";
+            lb[1] = this.timer.toString();
+            lb[2] = "Good luck!";
+            if (this.timer <= 0) {
+                // Reset the game
+                this.startGame(gameServer);
+            } else {
+                this.timer--;
+            }
+            break;
+        case 2:
+            lb[0] = "Players Remaining";
+            lb[1] = this.contenders.length + "/" + this.maxContenders;
+            lb[2] = "Time Limit:";
+            lb[3] = this.formatTime(this.timeLimit);
+            if (this.timeLimit < 0) {
+                // Timed out
+                this.endGameTimeout(gameServer);
+            } else {
+                this.timeLimit--;
+            }
+            break;
+        case 3:
+            lb[0] = "Congratulations";
+            lb[1] = this.winner.getName();
+            lb[2] = "for winning!";
+            if (this.timer <= 0) {
+                // Reset the game
+                this.onServerInit(gameServer);
+                // Respawn starting food
+                gameServer.startingFood();
+            } else {
+                lb[3] = "Game restarting in";
+                lb[4] = this.timer.toString();
+                this.timer--;
+            }
+            break;
+        case 4:
+            lb[0] = "Time Limit";
+            lb[1] = "Reached!";
+            if (this.timer <= 0) {
+                // Reset the game
+                this.onServerInit(gameServer);
+                // Respawn starting food
+                gameServer.startingFood();
+            } else {
+                lb[2] = "Game restarting in";
+                lb[3] = this.timer.toString();
+                this.timer--;
+            }
+        default:
+            break;
+    }
+};

--- a/src/gamemodes/Tournament.js
+++ b/src/gamemodes/Tournament.js
@@ -214,13 +214,11 @@ Tournament.prototype.updateLB = function (gameServer, lb) {
             break;
         case 3:
             lb[0] = "Congratulations";
-            lb[1] = this.winner.getName();
+            lb[1] = this.winner._name;
             lb[2] = "for winning!";
             if (this.timer <= 0) {
                 // Reset the game
-                this.onServerInit(gameServer);
-                // Respawn starting food
-                gameServer.startingFood();
+                process.exit(3);
             } else {
                 lb[3] = "Game restarting in";
                 lb[4] = this.timer.toString();
@@ -232,9 +230,7 @@ Tournament.prototype.updateLB = function (gameServer, lb) {
             lb[1] = "Reached!";
             if (this.timer <= 0) {
                 // Reset the game
-                this.onServerInit(gameServer);
-                // Respawn starting food
-                gameServer.startingFood();
+                process.exit(3);
             } else {
                 lb[2] = "Game restarting in";
                 lb[3] = this.timer.toString();

--- a/src/gamemodes/Tournament.js
+++ b/src/gamemodes/Tournament.js
@@ -128,9 +128,9 @@ Tournament.prototype.onServerInit = function (gameServer) {
 Tournament.prototype.onPlayerSpawn = function (gameServer, player) {
     // Only spawn players if the game hasnt started yet
     if ((this.gamePhase == 0) && (this.contenders.length < this.maxContenders)) {
-        player.setColor(gameServer.getRandomColor()); // Random color
+        player.color = gameServer.getRandomColor(); // Random color
         this.contenders.push(player); // Add to contenders list
-        gameServer.spawnPlayer(player);
+        gameServer.spawnPlayer(player, gameServer.randomPos());
         
         if (this.contenders.length == this.maxContenders) {
             // Start the game once there is enough players

--- a/src/gamemodes/index.js
+++ b/src/gamemodes/index.js
@@ -4,6 +4,8 @@ module.exports = {
     Teams: require('./Teams'),
     Experimental: require('./Experimental'),
     Rainbow: require('./Rainbow'),
+    Tournament: require('./Tournament'),
+    HungerGames: require('./HungerGames'),
 };
 
 var get = function (id) {
@@ -17,6 +19,12 @@ var get = function (id) {
             break;
         case 3: // Rainbow
             mode = new module.exports.Rainbow();
+            break;
+        case 4:// Tournament
+            mode = new module.exports.Tournament();
+            break;
+        case 5:// Hunger Games
+            mode = new module.exports.HungerGames();
             break;
         default: // FFA is default
             mode = new module.exports.FFA();

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -177,3 +177,15 @@ disableQ = 0
 serverMinions = 0
 collectPellets = 0
 defaultName = "minion"
+
+# [Gamemode]
+# Custom gamemode settings
+# tourneyTimeLimit: Time limit of the game, in minutes.
+# tourneyAutoFill: If set to a value higher than 0, the tournament match will automatically fill up with bots after value seconds
+# tourneyAutoFillPlayers: The timer for filling the server with bots will not count down unless there is this amount of real players
+tourneyMaxPlayers = 12
+tourneyPrepTime = 10
+tourneyEndTime = 30
+tourneyTimeLimit = 20
+tourneyAutoFill = 0
+tourneyAutoFillPlayers = 1


### PR DESCRIPTION
The gamemodes have a things needless (Like: Logger requires or Entity's requires), this fix this simple issues.

The HungerGames gamemode and Tournament gamemode not working in MultiOgar-Edited because the tick counter issue.

Explain:
The HungerGames take a leaderboard update for timer.
At begging of the start gamemode, HungerGames set `gameServer.run = false;` to players don't get moved from the Established position, and in the MainLoop of GameServer.js, to update the leaderboard (Needed to Tournament base gamemode timer), the leaderboard needs the condition `if (((this.tickCounter + 7) % 25) === 0)`, but, the variable tickCounter, IS ADDED IN the condition `if (this.run)`, this causes to the variable tickCounter don't get `this.tickCounter++;`, and if tickCounter don't get added one more, the leaderboard can't meet the condition, this are the bug from HungerGames and Tournament Gamemodes.

But, why is needed to add condition `this.gameMode.IsTournament`?
To detect if are tournament, and, if are, add a tick, because, if I add the tickCounter out of condition of `this.run`, this can call functions unnecessarily without players (In case of others Gamemodes, like FFA, Experimental....)

I have the correct positions from HungerGames, but, I hope people will at least try a little to do it for themselves.