### PR TITLE
Added ability to use '*' to accept user login from any IP adress

### DIFF
--- a/src/modules/PlayerCommand.js
+++ b/src/modules/PlayerCommand.js
@@ -39,7 +39,7 @@ PlayerCommand.prototype.userLogin = function (ip, password) {
         var user = this.gameServer.userList[i];
         if (user.password != password)
             continue;
-        if (user.ip && user.ip != ip)
+        if (user.ip && user.ip != ip && user.ip != "*") // * - means any IP
             continue;
         return user;
     }


### PR DESCRIPTION
If you wanna let login for some user from any IP, just set ip to **'*'** in **userRoles.json** 
```json
{ 
        "ip":"*", 
        "password":"pass",
        "role":"ADMIN",
        "name":"Local Administrator" 
}
```