### PR TITLE
Fixing clientBinding

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -275,7 +275,7 @@ GameServer.prototype.onClientSocketOpen = function (ws) {
             return;
         }
     }
-    if (this.config.clientBind.length && this.clientBind.indexOf(ws.upgradeReq.headers.origin) < 0) {
+    if (this.config.clientBind.length && ws.upgradeReq.headers.origin.indexOf(this.clientBind) < 0) {
         ws.close(1000, "Client not allowed");
         return;
     }


### PR DESCRIPTION
According to (https://www.w3schools.com/jsref/jsref_indexof.asp):
The` indexOf()` method returns the position of the first occurrence of a specified value in a string.
This method returns -1 if the value to search for never occurs.

`this.config.clientBind` is the value that should be contained in `ws.upgradeReq.headers.origin`.
The Index of `this.config.clientBind` has to be found in `ws.upgradeReq.headers.origin` and then compared wether its less then 0 or not.