### PR TITLE
Fixing leaderboard on Team gamemode.

### DIFF
--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -28,6 +28,8 @@ PlayerCell.prototype.onAdd = function (gameServer) {
     this.owner.cells.push(this);
     this.owner.socket.packetHandler.sendPacket(new Packet.AddNode(this.owner, this));
     this.gameServer.nodesPlayer.unshift(this);
+    // Gamemode actions
+    gameServer.gameMode.onCellAdd(this);
 };
 
 PlayerCell.prototype.onRemove = function (gameServer) {


### PR DESCRIPTION
With this simple fix, the leaderboard in Teams gamemode is working again.