### PR TITLE
New 'minionsOnLeaderboard' config

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -141,6 +141,7 @@ function GameServer() {
         serverMinions: 0, // Amount of minions each player gets once they spawn
         collectPellets: 0, // Enable collect pellets mode. To use just press P or Q. (Warning: this disables Q controls, so make sure that disableERT is 0)
         defaultName: "minion", // Default name for all minions if name is not specified using command (put <r> before the name for random skins!)
+        minionsOnLeaderboard: 0, // Whether or not to show minions on the leaderboard. (Set 0 to disable)
 
         /** TOURNAMENT **/
         tourneyMaxPlayers: 12, // Maximum number of participants for tournament style game modes

--- a/src/PlayerTracker.js
+++ b/src/PlayerTracker.js
@@ -203,7 +203,7 @@ PlayerTracker.prototype.updateTick = function() {
     if (this.isRemoved || this.isMinion)
         return; // do not update
     this.socket.packetHandler.process();
-    if (this.isMi) return;
+    if (this.isMi && this.gameServer.config.minionsOnLeaderboard) return;
 
     // update viewbox
     this.updateSpecView(this.cells.length);

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -177,6 +177,7 @@ splitVelocity = 780
 ; serverMinions: Amount of minions each player gets once they spawn
 ; collectPellets: Enable collect pellets mode for minions. To use, use the ERTPcontrol script and press "P"
 ; defaultName: Default name for all minions if name is not specified using command (put <r> before the name for random skins!)
+; minionsOnLeaderboard: Whether or not to show minions on the leaderboard. (Set 0 to disable)
 minionStartSize = 31.6227766017
 minionMaxStartSize = 31.6227766017
 minionCollideTeam = 0
@@ -185,6 +186,7 @@ disableQ = 0
 serverMinions = 0
 collectPellets = 0
 defaultName = "minion"
+minionsOnLeaderboard = 0
 
 # [Gamemode]
 # Custom gamemode settings


### PR DESCRIPTION
This config defines whether or not minion names will appear on the leaderboard.
The config will be set to 0 to remain in-line with the server default.
This config was made due to the amount of issues referencing minions on the leaderboard.