### PR TITLE
Additions to reset command

### DIFF
--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -131,11 +131,12 @@ Commands.list = {
     reset: function(gameServer, split) {
         var ent = split[1];
         if ("ejected" != ent && "food" != ent && "virus" != ent) {
-            for (Logger.warn("Removed " + gameServer.nodes.length + " nodes"); gameServer.nodes.length;) gameServer.removeNode(gameServer.nodes[0]);
+            for (; gameServer.nodes.length;) gameServer.removeNode(gameServer.nodes[0]);
             for (; gameServer.nodesEject.length;) gameServer.removeNode(gameServer.nodesEject[0]);
             for (; gameServer.nodesFood.length;) gameServer.removeNode(gameServer.nodesFood[0]);
             for (; gameServer.nodesVirus.length;) gameServer.removeNode(gameServer.nodesVirus[0]);
             Commands.list.killall(gameServer, split);
+            Logger.warn("Removed " + gameServer.nodes.length + " nodes");
         }
         if ("ejected" == ent) {
             for (; gameServer.nodesEject.length;) gameServer.removeNode(gameServer.nodesEject[0]);

--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -128,18 +128,27 @@ Commands.list = {
             "Quad nodes:     " + fillChar(scanNodeCount(gameServer.quadTree), " ", 4, true) + "\n" +
             "Quad items:     " + fillChar(scanItemCount(gameServer.quadTree), " ", 4, true));
     },
-    reset: function (gameServer, split) {
-        Logger.warn("Removed " + gameServer.nodes.length + " nodes");
-        // Remove all nodes in the entire server
-        while (gameServer.nodes.length)
-            gameServer.removeNode(gameServer.nodes[0]);
-        while (gameServer.nodesEjected.length)
-            gameServer.removeNode(gameServer.nodesEjected[0]);
-        while (gameServer.nodesFood.length)
-            gameServer.removeNode(gameServer.nodesFood[0]);
-        while (gameServer.nodesVirus.length)
-            gameServer.removeNode(gameServer.nodesVirus[0]);
-        Commands.list.killall(gameServer, split);
+    reset: function(gameServer, split) {
+        var ent = split[1];
+        if ("ejected" != ent && "food" != ent && "virus" != ent) {
+            for (Logger.warn("Removed " + gameServer.nodes.length + " nodes"); gameServer.nodes.length;) gameServer.removeNode(gameServer.nodes[0]);
+            for (; gameServer.nodesEject.length;) gameServer.removeNode(gameServer.nodesEject[0]);
+            for (; gameServer.nodesFood.length;) gameServer.removeNode(gameServer.nodesFood[0]);
+            for (; gameServer.nodesVirus.length;) gameServer.removeNode(gameServer.nodesVirus[0]);
+            Commands.list.killall(gameServer, split);
+        }
+        if ("ejected" == ent) {
+            for (; gameServer.nodesEject.length;) gameServer.removeNode(gameServer.nodesEject[0]);
+            Logger.print("Removed " + gameServer.nodesEject.length + " ejected nodes");
+        }
+        if ("food" == ent) {
+            for (; gameServer.nodesFood.length;) gameServer.removeNode(gameServer.nodesFood[0]);
+            Logger.print("Removed " + gameServer.nodesFood.length + " food nodes");
+        }
+        if ("virus" == ent) {
+            for (; gameServer.nodesVirus.length;) gameServer.removeNode(gameServer.nodesVirus[0]);
+            Logger.print("Removed " + gameServer.nodesFood.length + " virus nodes");
+        }
     },
     minion: function (gameServer, split) {
         var id = parseInt(split[1]);

--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -148,7 +148,7 @@ Commands.list = {
         }
         if ("virus" == ent) {
             for (; gameServer.nodesVirus.length;) gameServer.removeNode(gameServer.nodesVirus[0]);
-            Logger.print("Removed " + gameServer.nodesFood.length + " virus nodes");
+            Logger.print("Removed " + gameServer.nodesVirus.length + " virus nodes");
         }
     },
     minion: function (gameServer, split) {


### PR DESCRIPTION
This addition allows users to clear certain entity nodes while keeping the functionality o the original `reset` command. Typing in just `reset` will still clear all nodes like it does, but you can now exclude certain entities, and clear only certain entities off the map: `Food`, `Viruses`, and `Ejected Cells`.

- Clear food by entering `reset food`
- Clear viruses by entering `reset virus`
- Clear ejected cells by entering `reset ejected`

**EDIT:** I did not include players because there is already a `killall` command, and `reset` needs the `killall` command.