### PR TITLE
Major bug fix

### DIFF
--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -38,7 +38,7 @@ Virus.prototype.onEaten = function(cell) {
     var config = this.gameServer.config;
 
     var cellsLeft = (config.virusMaxCells || config.playerMaxCells) - cell.owner.cells.length;
-    if (cellsLeft === 0) return;
+    if (cellsLeft <= 0) return;
     var splitMin = config.virusMaxPoppedSize * config.virusMaxPoppedSize / 100;
     var cellMass = cell._mass, splits = [], splitCount, splitMass;
 


### PR DESCRIPTION
Fixes a bug that allows cells to split from viruses if the cell count is greater than `playerMaxCells`.
This would most likely be ran into when a player has `rec` mode.
Also, sorry @Megabyte918 I need you again lol